### PR TITLE
Docs for aws_s3_bucket content argument

### DIFF
--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -28,7 +28,11 @@ The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to put the file in.
 * `key` - (Required) The name of the object once it is in the bucket.
-* `source` - (Required) The path to the source file being uploaded to the bucket.
+* `source` - (Required unless `content` given) The path to the source file being uploaded to the bucket.
+* `content` - (Required unless `source` given) The literal content being uploaded to the bucket.
+
+Either `source` or `content` must be provided to specify the bucket content.
+These two arguments are mutually-exclusive.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Over in hashicorp/terraform#3200 you proposed a new ``content`` argument to ``aws_s3_bucket_object``. Here are some docs for it.